### PR TITLE
Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ if (KANON_INSTALL)
     list(APPEND kanon_export_targets kanon_net)
   endif ()
 
-  if (KANON_BUILD_PROTOBUF)
+  if (KANON_BUILD_PROTOBUF OR KANON_BUILD_PROTOBUF_RPC)
     list(APPEND kanon_export_targets kanon_protobuf)
   endif ()
   if (KANON_BUILD_PROTOBUF_RPC)

--- a/cmake/compile_flag.cmake
+++ b/cmake/compile_flag.cmake
@@ -16,27 +16,30 @@ else ()
 
   set(CXX_FLAGS 
   -Wall
-  -Wno-deprecated-declarations
   -Wextra
+  -Wno-deprecated-declarations
+  # Allow lambda local variable to 
+  # shadow th local variable of this function
+  # contains lambda
   -Wno-shadow
+  # Disable visibility hidden warning
   -Wno-attributes
-  -Wno-return-local-addr
-  -Wno-unused-parameter
-  -Wno-unused-function
-  -Wno-switch
-  -Wno-format-security
+
+  #-Wno-return-local-addr
+  #-Wno-unused-parameter
+  #-Wno-unused-function
+  #-Wno-switch
+  #-Wno-format-security
   # support INT2DOUBLE
-  -Wno-strict-aliasing
+  #-Wno-strict-aliasing
   # -Werror
+
   # make non-trivial(but like "trivial") class can reallocate
   -Wno-class-memaccess
   -Wno-implicit-fallthrough
-  -Wconversion
-  #-Wshadow
   -Wno-maybe-uninitialized
   -Wwrite-strings # in fact, this is default specified
   -pthread
-      
   # linker opt
   -rdynamic
   # machine opt

--- a/kanon/buffer/ring_buffer.h
+++ b/kanon/buffer/ring_buffer.h
@@ -153,7 +153,7 @@ RingBuffer<T>::RingBuffer(size_type n)
 
   status = ::unlink(path);
   if (status < 0) {
-    LOG_SYSERROR << "unlink temp file for ring buffer error";
+    LOG_SYSERROR_KANON << "unlink temp file for ring buffer error";
   }
 
   count_ = ROUNDUP_PGSIZE(n * sizeof(T));
@@ -202,7 +202,7 @@ RingBuffer<T>::RingBuffer(size_type n)
   status = ::close(fd);
 
   if (status < 0) {
-    LOG_SYSERROR << "close temp file for ring buffer error";
+    LOG_SYSERROR_KANON << "close temp file for ring buffer error";
   }
 
   assert(read_index_ == 0);

--- a/kanon/linux/net/buffer.cc
+++ b/kanon/linux/net/buffer.cc
@@ -40,8 +40,7 @@ usize kanon::BufferReadFromFd(Buffer &buffer, FdType fd, int &saved_errno)
   return (size_t)readen_bytes;
 }
 
-void kanon::BufferOverlapRecv(Buffer &buffer, FdType fd, int &saved_errno,
-                              void *overlap)
+void kanon::BufferOverlapRecv(Buffer &, FdType, int &, void *)
 {
   LOG_FATAL << "BufferOverlapRecv() isn't implemented for Linux";
 }

--- a/kanon/linux/net/channel.cc
+++ b/kanon/linux/net/channel.cc
@@ -69,7 +69,7 @@ void Channel::HandleEvents(TimeStamp receive_time)
    * \see https://stackoverflow.com/questions/56177060/pollhup-vs-pollrdhup
    */
   if ((revents_ & POLLHUP) && !(revents_ & POLLIN)) {
-    LOG_WARN << "fd = " << fd_ << " POLLHUP happened";
+    LOG_WARN_KANON << "fd = " << fd_ << " POLLHUP happened";
 
     if (close_callback_) close_callback_();
   }
@@ -89,7 +89,7 @@ void Channel::HandleEvents(TimeStamp receive_time)
    */
   if (revents_ & (POLLERR | POLLNVAL)) {
     if (revents_ & POLLNVAL) {
-      LOG_WARN << "fd = " << fd_ << " POLLNVAL(fd not open) happend";
+      LOG_WARN_KANON << "fd = " << fd_ << " POLLNVAL(fd not open) happend";
     }
     if (error_callback_) error_callback_();
   }

--- a/kanon/linux/net/chunk_list.cc
+++ b/kanon/linux/net/chunk_list.cc
@@ -53,8 +53,7 @@ ChunkList::SizeType kanon::ChunkListWriteFd(ChunkList &buffer, FdType fd,
   return ret;
 }
 
-void kanon::ChunkListOverlapSend(ChunkList &buffer, FdType fd, int &saved_errno,
-                                 void *overlap)
+void kanon::ChunkListOverlapSend(ChunkList &, FdType, int &, void *)
 {
   LOG_FATAL << "ChunkListOverlapSend() isn't implemented for Linux";
 }

--- a/kanon/linux/net/connection/connection_base.inl
+++ b/kanon/linux/net/connection/connection_base.inl
@@ -42,7 +42,7 @@ void ConnectionBase<D>::SendInLoopForBuf(InputBuffer &buffer)
                   << "], fd = " << channel_->GetFd();
 
   if (state_ != kConnected) {
-    LOG_WARN << "This connection[" << name_
+    LOG_WARN_KANON << "This connection[" << name_
              << "] is not connected, don't send any message";
     return;
   }
@@ -61,7 +61,7 @@ void ConnectionBase<D>::SendInLoopForBuf(InputBuffer &buffer)
     auto n = ChunkListWriteFd(output_buffer_, channel_->GetFd(), saved_errno);
 
     if (saved_errno && saved_errno != EAGAIN) {
-      LOG_SYSERROR << "write unexpected error occurred";
+      LOG_SYSERROR_KANON << "write unexpected error occurred";
     }
 
     if (n > 0) {
@@ -108,7 +108,7 @@ void ConnectionBase<D>::SendInLoopForChunkList(OutputBuffer &buffer)
   auto write_n = ChunkListWriteFd(buffer, channel_->GetFd(), saved_errno);
 
   if (saved_errno && saved_errno != EAGAIN) {
-    LOG_SYSERROR << "write unexpected error occurred";
+    LOG_SYSERROR_KANON << "write unexpected error occurred";
   }
 
   if (write_n > 0) {
@@ -151,7 +151,7 @@ void ConnectionBase<D>::SendInLoop(void const *data, size_t len)
   // But connection also can be closed in the phase 2
   // when this is called in phase 3
   if (state_ != kConnected) {
-    LOG_WARN << "This connection [" << name_
+    LOG_WARN_KANON << "This connection [" << name_
              << "] is not connected, don't send any message";
     return;
   }
@@ -243,7 +243,7 @@ void ConnectionBase<D>::SendInLoop(void const *data, size_t len)
       }
     } else {
       if (errno != EAGAIN) // EWOULDBLOCK
-        LOG_SYSERROR << "write unexpected error occurred";
+        LOG_SYSERROR_KANON << "write unexpected error occurred";
       return;
     }
   }

--- a/kanon/linux/net/connector.cc
+++ b/kanon/linux/net/connector.cc
@@ -60,7 +60,7 @@ void Connector::Connect()
       break;
 
     default:
-      LOG_SYSERROR << "Unexpected error in Connector::Connect()";
+      LOG_SYSERROR_KANON << "Unexpected error in Connector::Connect()";
       sock::Close(sockfd);
   }
 }
@@ -88,7 +88,7 @@ void Connector::CompleteConnect(FdType sockfd)
 
       if (err) {
         // Fatal errors have handled in Connect()
-        LOG_WARN << "SO_ERROR = " << err << " " << strerror_tl(err);
+        LOG_WARN_KANON << "SO_ERROR = " << err << " " << strerror_tl(err);
         Retry(sockfd);
       } else if (sock::IsSelfConnect(sockfd)) {
         // Self connection happend only when:
@@ -102,7 +102,7 @@ void Connector::CompleteConnect(FdType sockfd)
         // \see /proc/sys/net/ipv4/ip_local_port_range
         // \see
         // https://github.com/pirDOL/kaka/blob/master/Miscellaneous/TCP-client-self-connect.md
-        LOG_WARN << "self connect";
+        LOG_WARN_KANON << "self connect";
         // Discard the client address and retry
         // until self connection is skipped
         Retry(sockfd);
@@ -114,13 +114,13 @@ void Connector::CompleteConnect(FdType sockfd)
           if (new_connection_callback_)
             new_connection_callback_(sockfd);
           else {
-            LOG_WARN << "There is no new connection callback, cannot to create "
+            LOG_WARN_KANON << "There is no new connection callback, cannot to create "
                         "connection";
           }
           LOG_TRACE_KANON << "Connection is established successfully";
         } else {
           // Must after Stop() is called
-          LOG_WARN << "Cannot to complete connect since user stop it";
+          LOG_WARN_KANON << "Cannot to complete connect since user stop it";
           sock::Close(sockfd);
         }
       }
@@ -133,7 +133,7 @@ void Connector::CompleteConnect(FdType sockfd)
       ResetChannel();
       int err = sock::GetSocketError(sockfd);
       if (err) {
-        LOG_ERROR << "SO_ERROR = " << err << " " << strerror_tl(err);
+        LOG_ERROR_KANON << "SO_ERROR = " << err << " " << strerror_tl(err);
       }
 
       Retry(sockfd);

--- a/kanon/linux/net/epoller.cc
+++ b/kanon/linux/net/epoller.cc
@@ -70,7 +70,7 @@ TimeStamp Epoller::Poll(int ms, ChannelVec &active_channels)
     // use saved_errno to avoid misunderstand error
     if (saved_errno != EINTR) {
       errno = saved_errno;
-      LOG_SYSERROR << "epoll_wait() error occurred";
+      LOG_SYSERROR_KANON << "epoll_wait() error occurred";
     }
   }
 

--- a/kanon/linux/net/poller.cc
+++ b/kanon/linux/net/poller.cc
@@ -55,7 +55,7 @@ TimeStamp Poller::Poll(int ms, ChannelVec &active_channels) KANON_NOEXCEPT
     LOG_TRACE_KANON << "none events are ready";
   } else {
     if (ret != EINTR) {
-      LOG_SYSERROR << "Poll() error occurred";
+      LOG_SYSERROR_KANON << "Poll() error occurred";
     }
   }
 

--- a/kanon/linux/net/sock_api.cc
+++ b/kanon/linux/net/sock_api.cc
@@ -53,7 +53,7 @@ FdType sock::Accept(FdType fd, sockaddr_in6 *addr) KANON_NOEXCEPT
       case EINTR:
       case EMFILE: // per-process limit on the number of open fd has been
                    // reached
-        LOG_SYSERROR << "accept() expected error occurred";
+        LOG_SYSERROR_KANON << "accept() expected error occurred";
         break;
       case EFAULT:
       case EINVAL:

--- a/kanon/linux/net/timer/timer_queue.cc
+++ b/kanon/linux/net/timer/timer_queue.cc
@@ -26,7 +26,7 @@ static KANON_INLINE int CreateTimerFd() KANON_NOEXCEPT
   LOG_TRACE_KANON << "Timer Fd: " << timerfd << " created";
 
   if (timerfd < 0) {
-    LOG_SYSERROR << "::timer_create() error occurred";
+    LOG_SYSERROR_KANON << "::timer_create() error occurred";
   }
 
   return timerfd;
@@ -87,7 +87,7 @@ static KANON_INLINE void SetTimerFd(int timerfd, Timer const &timer,
 
   // The default interpretation of .it_value is relative time
   if (::timerfd_settime(timerfd, 0, &new_value, NULL)) {
-    LOG_SYSERROR << "::timerfd_settime() error occurred";
+    LOG_SYSERROR_KANON << "::timerfd_settime() error occurred";
   } else {
     LOG_TRACE_KANON << "Reset successfully";
   }
@@ -99,7 +99,7 @@ static KANON_INLINE void ReadTimerFd(int timerfd) KANON_NOEXCEPT
   uint64_t n = 0;
 
   if ((n = ::read(timerfd, &dummy, sizeof dummy)) != sizeof dummy) {
-    LOG_SYSERROR << "::read() of timerfd error occurred";
+    LOG_SYSERROR_KANON << "::read() of timerfd error occurred";
   } else {
     LOG_TRACE_KANON << "Read " << n << " bytes";
   }
@@ -116,7 +116,7 @@ TimerQueue::TimerQueue(EventLoop *loop)
       std::bind(&TimerQueue::ProcessAllExpiredTimers, this, _1));
 
   timer_channel_->SetErrorCallback([]() {
-    LOG_SYSERROR << "Timer event handler error occurred";
+    LOG_SYSERROR_KANON << "Timer event handler error occurred";
   });
 
   timer_channel_->EnableReading();
@@ -210,12 +210,12 @@ void TimerQueue::ProcessAllExpiredTimers(TimeStamp recv_time)
       timer->run();
     }
     catch (std::exception const &ex) {
-      LOG_ERROR << "caught the std::exception in calling of timer callback";
-      LOG_ERROR << "exception message: " << ex.what();
+      LOG_ERROR_KANON << "caught the std::exception in calling of timer callback";
+      LOG_ERROR_KANON << "exception message: " << ex.what();
       KANON_RETHROW;
     }
     catch (...) {
-      LOG_ERROR << "caught the unknown exception in calling of timer callback";
+      LOG_ERROR_KANON << "caught the unknown exception in calling of timer callback";
       KANON_RETHROW;
     }
   }

--- a/kanon/log/logger.cc
+++ b/kanon/log/logger.cc
@@ -37,6 +37,10 @@ static char const *g_logLevelColor[] = {CYAN, BLUE,  GREEN, YELLOW,
 static Logger::LogLevel initLogLevel() KANON_NOEXCEPT
 {
   if (!g_all_log) return Logger::KANON_LL_OFF;
+  auto log_enable = ::getenv("KANON_LOG_ENABLE");
+  if (log_enable && !StrCaseCompare(log_enable, "0")) {
+    g_kanon_log = 0;
+  }
 
   auto log_level = ::getenv("KANON_LOG");
   if (!log_level) return Logger::LogLevel::KANON_LL_INFO;

--- a/kanon/log/logger.cc
+++ b/kanon/log/logger.cc
@@ -20,12 +20,7 @@ namespace kanon {
 static KANON_TLS time_t t_lastSecond = 0;
 static KANON_TLS char t_timebuf[64] = {0};
 
-#ifndef NDEBUG
 bool g_kanon_log = true;
-#else
-bool g_kanon_log = false;
-#endif
-
 bool g_all_log = true;
 
 bool Logger::need_color_ = true;
@@ -41,16 +36,30 @@ static char const *g_logLevelColor[] = {CYAN, BLUE,  GREEN, YELLOW,
 
 static Logger::LogLevel initLogLevel() KANON_NOEXCEPT
 {
-  char *env = nullptr;
-  if ((env = ::getenv("KANON_NDEBUG")) && strcmp(env, "1") == 0)
-    return Logger::LogLevel::KANON_LL_INFO;
+  if (!g_all_log) return Logger::KANON_LL_OFF;
 
-  if ((env = ::getenv("KANON_TRACE")) && strcmp(env, "1") == 0)
+  auto log_level = ::getenv("KANON_LOG");
+  if (!log_level) return Logger::LogLevel::KANON_LL_INFO;
+
+  if (!StrCaseCompare(log_level, "trace")) {
     return Logger::LogLevel::KANON_LL_TRACE;
-
-  if ((env = ::getenv("KANON_DEBUG")) && strcmp(env, "1") == 0)
+  }
+  if (!StrCaseCompare(log_level, "debug")) {
     return Logger::LogLevel::KANON_LL_DEBUG;
-
+  }
+  if (!StrCaseCompare(log_level, "warn") ||
+      !StrCaseCompare(log_level, "warning")) {
+    return Logger::LogLevel::KANON_LL_WARN;
+  }
+  if (!StrCaseCompare(log_level, "error")) {
+    return Logger::LogLevel::KANON_LL_ERROR;
+  }
+  if (!StrCaseCompare(log_level, "fatal")) {
+    return Logger::LogLevel::KANON_LL_FATAL;
+  }
+  if (!StrCaseCompare(log_level, "off")) {
+    return Logger::LogLevel::KANON_LL_OFF;
+  }
   return Logger::LogLevel::KANON_LL_INFO;
 }
 
@@ -121,6 +130,8 @@ Logger::Logger(SourceFile file, size_t line, LogLevel level)
 Logger::Logger(SourceFile basefile, size_t line, LogLevel level, bool is_sys)
   : Logger(basefile, line, level)
 {
+  // dummy parameter
+  KANON_UNUSED(is_sys);
   char error_buf[4096];
 #ifdef KANON_ON_UNIX
   auto savedErrno = errno;
@@ -144,8 +155,7 @@ Logger::~Logger() KANON_NOEXCEPT
   stream_ << " - " << basename_ << ":" << line_ << "\n";
   output_callback_(stream_.data(), stream_.size());
 
-  if (cur_log_level_ == KANON_LL_FATAL || cur_log_level_ == KANON_LL_SYS_FATAL)
-  {
+  if (cur_log_level_ & KANON_LL_FATAL) {
     flush_callback_();
     abort();
   }

--- a/kanon/log/logger.h
+++ b/kanon/log/logger.h
@@ -21,12 +21,18 @@ KANON_CORE_API extern bool g_all_log;
 /**
  * Enable/Disable the logging of kanon library
  */
-KANON_INLINE void SetKanonLog(bool val) KANON_NOEXCEPT { g_kanon_log = val; }
+KANON_INLINE void SetKanonLog(bool val) KANON_NOEXCEPT
+{
+  g_kanon_log = val;
+}
 
 /**
  * Control the logging of logger(i.e. All logs output by kanon)
  */
-KANON_INLINE void EnableAllLog(bool value) KANON_NOEXCEPT { g_all_log = value; }
+KANON_INLINE void EnableAllLog(bool value) KANON_NOEXCEPT
+{
+  g_all_log = value;
+}
 
 /**
  * \brief Format the log message to specified device
@@ -62,16 +68,17 @@ class Logger : noncopyable {
    * e.g. current log level is DEBUG, user call LOG_TRACE is no effect
    * i.e. Log condiftion is current log level <= XXX
    */
-  enum KANON_CORE_API LogLevel {
+  enum LogLevel {
     KANON_LL_TRACE = 0,
-    KANON_LL_DEBUG,
-    KANON_LL_INFO,
-    KANON_LL_WARN,
-    KANON_LL_ERROR,
-    KANON_LL_FATAL,
-    KANON_LL_SYS_ERROR,
-    KANON_LL_SYS_FATAL,
-    KANON_LL_NUM_LOG_LEVEL,
+    KANON_LL_DEBUG = 1,
+    KANON_LL_INFO = 2,
+    KANON_LL_WARN = 3,
+    KANON_LL_ERROR = (1 << 2),
+    KANON_LL_SYS_ERROR = KANON_LL_ERROR + 1,
+    KANON_LL_FATAL = (1 << 3),
+    KANON_LL_SYS_FATAL = KANON_LL_FATAL + 1,
+    KANON_LL_NUM_LOG_LEVEL = 8,
+    KANON_LL_OFF = (1 << 4),
   };
 
   // Since __FIEL__ is fullname, including all parent path
@@ -129,9 +136,15 @@ class Logger : noncopyable {
   // Do output and flush
   KANON_CORE_API ~Logger() KANON_NOEXCEPT;
 
-  KANON_INLINE LogStream &stream() KANON_NOEXCEPT { return stream_; }
+  KANON_INLINE LogStream &stream() KANON_NOEXCEPT
+  {
+    return stream_;
+  }
 
-  KANON_INLINE static void SetColor(bool c) KANON_NOEXCEPT { need_color_ = c; }
+  KANON_INLINE static void SetColor(bool c) KANON_NOEXCEPT
+  {
+    need_color_ = c;
+  }
   KANON_INLINE static LogLevel GetLogLevel() KANON_NOEXCEPT
   {
     return log_level_;
@@ -186,9 +199,40 @@ KANON_CORE_API char const *win_last_strerror(int win_errno);
 KANON_CORE_API void DefaultFlush();
 KANON_CORE_API void DefaultOutput(char const *, size_t);
 
+#ifdef LOG_TRACE
+#  undef LOG_TRACE
+#endif
+
+#ifdef LOG_DEBUG
+#  undef LOG_DEBUG
+#endif
+
+#ifdef LOG_INFO
+#  undef LOG_INFO
+#endif
+
+#ifdef LOG_WARN
+#  undef LOG_WARN
+#endif
+
+#ifdef LOG_ERROR
+#  undef LOG_ERROR
+#endif
+
+#ifdef LOG_FATAL
+#  undef LOG_FATAL
+#endif
+
+#ifdef LOG_SYSERROR
+#  undef LOG_SYSERROR
+#endif
+
+#ifdef LOG_SYSFATAL
+#  undef LOG_SYSFATAL
+#endif
+
 #define LOG_TRACE                                                              \
-  if (kanon::Logger::GetLogLevel() <= kanon::Logger::KANON_LL_TRACE &&         \
-      kanon::g_all_log)                                                        \
+  if (kanon::Logger::GetLogLevel() <= kanon::Logger::KANON_LL_TRACE)           \
   kanon::Logger(__FILE__, __LINE__, kanon::Logger::KANON_LL_TRACE, __func__)   \
       .stream()
 
@@ -196,8 +240,7 @@ KANON_CORE_API void DefaultOutput(char const *, size_t);
   if (g_kanon_log) LOG_TRACE
 
 #define LOG_DEBUG                                                              \
-  if (kanon::Logger::GetLogLevel() <= kanon::Logger::KANON_LL_DEBUG &&         \
-      kanon::g_all_log)                                                        \
+  if (kanon::Logger::GetLogLevel() <= kanon::Logger::KANON_LL_DEBUG)           \
   kanon::Logger(__FILE__, __LINE__, kanon::Logger::KANON_LL_DEBUG, __func__)   \
       .stream()
 
@@ -205,29 +248,38 @@ KANON_CORE_API void DefaultOutput(char const *, size_t);
   if (g_kanon_log) LOG_DEBUG
 
 #define LOG_INFO                                                               \
-  if (kanon::Logger::GetLogLevel() <= kanon::Logger::KANON_LL_INFO &&          \
-      kanon::g_all_log)                                                        \
+  if (kanon::Logger::GetLogLevel() <= kanon::Logger::KANON_LL_INFO)            \
   kanon::Logger(__FILE__, __LINE__, kanon::Logger::KANON_LL_INFO).stream()
 
+#define LOG_INFO_KANON                                                         \
+  if (g_kanon_log) LOG_INFO
+
 #define LOG_WARN                                                               \
-  if (kanon::g_all_log)                                                        \
+  if (kanon::Logger::GetLogLevel() <= kanon::Logger::KANON_LL_WARN)            \
   kanon::Logger(__FILE__, __LINE__, kanon::Logger::KANON_LL_WARN).stream()
 
+#define LOG_WARN_KANON                                                         \
+  if (g_kanon_log) LOG_WARN
+
 #define LOG_ERROR                                                              \
-  if (kanon::g_all_log)                                                        \
+  if (kanon::Logger::GetLogLevel() <= kanon::Logger::KANON_LL_ERROR)           \
   kanon::Logger(__FILE__, __LINE__, kanon::Logger::KANON_LL_ERROR).stream()
 
+#define LOG_ERROR_KANON                                                        \
+  if (g_kanon_log) LOG_ERROR
+
 #define LOG_FATAL                                                              \
-  if (kanon::g_all_log)                                                        \
   kanon::Logger(__FILE__, __LINE__, kanon::Logger::KANON_LL_FATAL).stream()
 
 #define LOG_SYSERROR                                                           \
-  if (kanon::g_all_log)                                                        \
+  if (kanon::Logger::GetLogLevel() <= kanon::Logger::KANON_LL_SYS_ERROR)       \
   kanon::Logger(__FILE__, __LINE__, kanon::Logger::KANON_LL_SYS_ERROR, true)   \
       .stream()
 
+#define LOG_SYSERROR_KANON                                                     \
+  if (g_kanon_log) LOG_SYSERROR
+
 #define LOG_SYSFATAL                                                           \
-  if (kanon::g_all_log)                                                        \
   kanon::Logger(__FILE__, __LINE__, kanon::Logger::KANON_LL_SYS_FATAL, true)   \
       .stream()
 

--- a/kanon/log/logger.h
+++ b/kanon/log/logger.h
@@ -236,37 +236,22 @@ KANON_CORE_API void DefaultOutput(char const *, size_t);
   kanon::Logger(__FILE__, __LINE__, kanon::Logger::KANON_LL_TRACE, __func__)   \
       .stream()
 
-#define LOG_TRACE_KANON                                                        \
-  if (g_kanon_log) LOG_TRACE
-
 #define LOG_DEBUG                                                              \
   if (kanon::Logger::GetLogLevel() <= kanon::Logger::KANON_LL_DEBUG)           \
   kanon::Logger(__FILE__, __LINE__, kanon::Logger::KANON_LL_DEBUG, __func__)   \
       .stream()
 
-#define LOG_DEBUG_KANON                                                        \
-  if (g_kanon_log) LOG_DEBUG
-
 #define LOG_INFO                                                               \
   if (kanon::Logger::GetLogLevel() <= kanon::Logger::KANON_LL_INFO)            \
   kanon::Logger(__FILE__, __LINE__, kanon::Logger::KANON_LL_INFO).stream()
-
-#define LOG_INFO_KANON                                                         \
-  if (g_kanon_log) LOG_INFO
 
 #define LOG_WARN                                                               \
   if (kanon::Logger::GetLogLevel() <= kanon::Logger::KANON_LL_WARN)            \
   kanon::Logger(__FILE__, __LINE__, kanon::Logger::KANON_LL_WARN).stream()
 
-#define LOG_WARN_KANON                                                         \
-  if (g_kanon_log) LOG_WARN
-
 #define LOG_ERROR                                                              \
   if (kanon::Logger::GetLogLevel() <= kanon::Logger::KANON_LL_ERROR)           \
   kanon::Logger(__FILE__, __LINE__, kanon::Logger::KANON_LL_ERROR).stream()
-
-#define LOG_ERROR_KANON                                                        \
-  if (g_kanon_log) LOG_ERROR
 
 #define LOG_FATAL                                                              \
   kanon::Logger(__FILE__, __LINE__, kanon::Logger::KANON_LL_FATAL).stream()
@@ -276,13 +261,30 @@ KANON_CORE_API void DefaultOutput(char const *, size_t);
   kanon::Logger(__FILE__, __LINE__, kanon::Logger::KANON_LL_SYS_ERROR, true)   \
       .stream()
 
-#define LOG_SYSERROR_KANON                                                     \
-  if (g_kanon_log) LOG_SYSERROR
-
 #define LOG_SYSFATAL                                                           \
   kanon::Logger(__FILE__, __LINE__, kanon::Logger::KANON_LL_SYS_FATAL, true)   \
       .stream()
 
+// Kanon lib macro
+#define LOG_TRACE_KANON                                                        \
+  if (g_kanon_log) LOG_TRACE
+
+#define LOG_DEBUG_KANON                                                        \
+  if (g_kanon_log) LOG_DEBUG
+
+#define LOG_INFO_KANON                                                         \
+  if (g_kanon_log) LOG_INFO
+
+#define LOG_WARN_KANON                                                         \
+  if (g_kanon_log) LOG_WARN
+
+#define LOG_ERROR_KANON                                                        \
+  if (g_kanon_log) LOG_ERROR
+
+#define LOG_SYSERROR_KANON                                                     \
+  if (g_kanon_log) LOG_SYSERROR
+
+// Format logging macros
 #define FMT_LOG_TRACE(fmt, ...)                                                \
   LOG_TRACE << kanon::LogFmtStream(fmt, __VA_ARGS__).ToStringView()
 

--- a/kanon/net/connection/connection_base.cc
+++ b/kanon/net/connection/connection_base.cc
@@ -55,7 +55,7 @@ void ConnectionBase<D>::ConnectionEstablished()
   // and call the OnConnection callback which
   // is set by user or default.
   channel_->EnableReading();
-  LOG_DEBUG << "Fd = " << channel_->GetFd();
+  LOG_DEBUG_KANON << "Fd = " << channel_->GetFd();
 
 #ifdef KANON_ON_WIN
   int saved_errno = 0;
@@ -109,7 +109,7 @@ void ConnectionBase<D>::HandleLtRead(TimeStamp recv_time)
     errno = saved_errno;
 
     if (errno != EAGAIN) {
-      LOG_SYSERROR << "Read event handle error";
+      LOG_SYSERROR_KANON << "Read event handle error";
       HandleError();
     }
   } else if (n == 0) {
@@ -127,7 +127,7 @@ void ConnectionBase<D>::HandleLtRead(TimeStamp recv_time)
       message_callback_(this->shared_from_this(), input_buffer_, recv_time);
     } else {
       input_buffer_.AdvanceAll();
-      LOG_WARN << "If user want to process message from peer, should set "
+      LOG_WARN_KANON << "If user want to process message from peer, should set "
                   "proper message_callback_";
     }
   }
@@ -160,7 +160,7 @@ void ConnectionBase<D>::HandleEtRead(TimeStamp recv_time)
 
     if (saved_errno != 0) {
       if (saved_errno != EAGAIN) {
-        LOG_SYSERROR << "Read event handle error";
+        LOG_SYSERROR_KANON << "Read event handle error";
         HandleError();
       } else {
         break;
@@ -181,7 +181,7 @@ void ConnectionBase<D>::HandleEtRead(TimeStamp recv_time)
       message_callback_(this->shared_from_this(), input_buffer_, recv_time);
     } else {
       input_buffer_.AdvanceAll();
-      LOG_WARN << "If user want to process message from peer, should set "
+      LOG_WARN_KANON << "If user want to process message from peer, should set "
                   "proper message_callback_";
     }
   }
@@ -210,7 +210,7 @@ void ConnectionBase<D>::HandleLtWrite()
                   << ", fd: " << channel_->GetFd() << "]";
 
   if (saved_errno && saved_errno != EAGAIN) {
-    LOG_SYSERROR << "Write event handle error";
+    LOG_SYSERROR_KANON << "Write event handle error";
     HandleError();
   }
 
@@ -293,7 +293,7 @@ void ConnectionBase<D>::HandleEtWrite()
 
     if (saved_errno) {
       if (saved_errno != EAGAIN) {
-        LOG_SYSERROR << "Write event handle error";
+        LOG_SYSERROR_KANON << "Write event handle error";
         HandleError();
       }
     }
@@ -332,7 +332,7 @@ void ConnectionBase<D>::HandleError()
 {
   loop_->AssertInThread();
   int err = sock::GetSocketError(channel_->GetFd());
-  LOG_SYSERROR << "ConnectionBase<D> [" << name_ << "] - [errno: " << err
+  LOG_SYSERROR_KANON << "ConnectionBase<D> [" << name_ << "] - [errno: " << err
                << "; errmsg: " << strerror_tl(err) << "]";
 }
 

--- a/kanon/net/connection/tcp_connection.h
+++ b/kanon/net/connection/tcp_connection.h
@@ -75,13 +75,14 @@ class TcpConnection : public ConnectionBase<TcpConnection> {
                             std::allocator<TcpConnection>());
   }
 
-  static TcpConnectionPtr
+  static KANON_DEPRECATED_ATTR TcpConnectionPtr
   NewTcpConnectionRaw(EventLoop *loop, std::string const &name, int sockfd,
                       InetAddr const &local_addr, InetAddr const &peer_addr)
   {
     return TcpConnectionPtr(
         new TcpConnection(loop, name, sockfd, local_addr, peer_addr),
         [](TcpConnection *ptr) {
+          KANON_UNUSED(ptr);
           LOG_TRACE << "Don't delete the connection to reuse";
         });
   }
@@ -108,9 +109,15 @@ class TcpConnection : public ConnectionBase<TcpConnection> {
   //! Whether disable keep-alive timer
   KANON_NET_API void SetKeepAlive(bool flag) KANON_NOEXCEPT;
 
-  InetAddr const &GetLocalAddr() const KANON_NOEXCEPT { return local_addr_; }
+  InetAddr const &GetLocalAddr() const KANON_NOEXCEPT
+  {
+    return local_addr_;
+  }
 
-  InetAddr const &GetPeerAddr() const KANON_NOEXCEPT { return peer_addr_; }
+  InetAddr const &GetPeerAddr() const KANON_NOEXCEPT
+  {
+    return peer_addr_;
+  }
 
  private:
   InetAddr const local_addr_;

--- a/kanon/net/connection/tcp_connection.h
+++ b/kanon/net/connection/tcp_connection.h
@@ -83,7 +83,7 @@ class TcpConnection : public ConnectionBase<TcpConnection> {
         new TcpConnection(loop, name, sockfd, local_addr, peer_addr),
         [](TcpConnection *ptr) {
           KANON_UNUSED(ptr);
-          LOG_TRACE << "Don't delete the connection to reuse";
+          LOG_TRACE_KANON << "Don't delete the connection to reuse";
         });
   }
 

--- a/kanon/net/connector.cc
+++ b/kanon/net/connector.cc
@@ -84,7 +84,7 @@ void Connector::Restrat()
      *      if connection is not established.
      */
     if (state_ != kConnected) {
-      // LOG_WARN << "Restart() must be used for reconnecting when passive
+      // LOG_WARN_KANON << "Restart() must be used for reconnecting when passive
       // closed by peer";
     }
     SetState(State::kDisconnected);

--- a/kanon/net/event_loop.cc
+++ b/kanon/net/event_loop.cc
@@ -51,7 +51,7 @@ static KANON_INLINE int CreateEventFd() KANON_NOEXCEPT
   LOG_TRACE_KANON << "eventfd: " << evfd << " created";
 
   if (evfd < 0) {
-    LOG_SYSERROR << "eventfd() error occurred";
+    LOG_SYSERROR_KANON << "eventfd() error occurred";
   }
 
   return evfd;
@@ -68,14 +68,14 @@ static KANON_INLINE void ReadEventFd(int evfd) KANON_NOEXCEPT
 {
   uint64_t dummy;
   if (sizeof dummy != ::read(evfd, &dummy, sizeof dummy))
-    LOG_SYSERROR << "ReadEventFd() error occurred";
+    LOG_SYSERROR_KANON << "ReadEventFd() error occurred";
 }
 
 static KANON_INLINE void WriteEventFd(int evfd) KANON_NOEXCEPT
 {
   uint64_t dummy = 1;
   if (sizeof dummy != ::write(evfd, &dummy, sizeof dummy))
-    LOG_SYSERROR << "WriteEventFd() error occurred";
+    LOG_SYSERROR_KANON << "WriteEventFd() error occurred";
 }
 #endif
 
@@ -180,13 +180,13 @@ void EventLoop::RunInLoop(FunctorCallback cb)
       cb();
     }
     catch (std::exception const &ex) {
-      LOG_ERROR << "std::exception(including its derived class) is caught in "
+      LOG_ERROR_KANON << "std::exception(including its derived class) is caught in "
                    "RunInLoop()";
-      LOG_ERROR << "Reason: " << ex.what();
+      LOG_ERROR_KANON << "Reason: " << ex.what();
       KANON_RETHROW;
     }
     catch (...) {
-      LOG_ERROR << "Unknown exception is caught in RunInLoop()";
+      LOG_ERROR_KANON << "Unknown exception is caught in RunInLoop()";
       KANON_RETHROW;
     }
   } else {
@@ -248,13 +248,13 @@ void EventLoop::CallFunctors()
       }
     }
     catch (std::exception const &ex) {
-      LOG_ERROR << "std::exception caught in CallFunctors()";
-      LOG_ERROR << "Reason: " << ex.what();
+      LOG_ERROR_KANON << "std::exception caught in CallFunctors()";
+      LOG_ERROR_KANON << "Reason: " << ex.what();
       calling_functors_ = false;
       KANON_RETHROW;
     }
     catch (...) {
-      LOG_ERROR << "Unknown exception caught in CallFunctors()";
+      LOG_ERROR_KANON << "Unknown exception caught in CallFunctors()";
       calling_functors_ = false;
       KANON_RETHROW;
     }
@@ -300,7 +300,7 @@ void EventLoop::Quit() KANON_NOEXCEPT
 
 TimerId EventLoop::RunAt(TimerCallback cb, TimeStamp expiration)
 {
-  LOG_DEBUG << "expiration = " << expiration.ToFormattedString();
+  LOG_DEBUG_KANON << "expiration = " << expiration.ToFormattedString();
   return timer_queue_->AddTimer(std::move(cb), expiration,
                                 0.0);
 }

--- a/kanon/net/inet_addr.cc
+++ b/kanon/net/inet_addr.cc
@@ -258,9 +258,9 @@ std::vector<InetAddr> InetAddr::Resolve(StringArg hostname, StringArg service,
       }
     }
   } else {
-    LOG_SYSERROR << "Resolve the hostname to address error: "
+    LOG_SYSERROR_KANON << "Resolve the hostname to address error: "
                  << ::gai_strerror(ret);
-    LOG_SYSERROR << "User can retry get address later";
+    LOG_SYSERROR_KANON << "User can retry get address later";
   }
 
   return addrs;

--- a/kanon/net/sock_api.cc
+++ b/kanon/net/sock_api.cc
@@ -90,9 +90,9 @@ void sock::SetReuseAddr(FdType fd, int flag) KANON_NOEXCEPT
   auto ret = ::setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, (char const *)&flag,
                           static_cast<socklen_t>(sizeof flag));
   if (ret < 0) {
-    LOG_SYSERROR << "setsockopt error(SO_REUSEADDR)";
+    LOG_SYSERROR_KANON << "setsockopt error(SO_REUSEADDR)";
   } else {
-    LOG_INFO << "SO_REUSEADDR option is set to " << static_cast<bool>(flag);
+    LOG_INFO_KANON << "SO_REUSEADDR option is set to " << static_cast<bool>(flag);
   }
 }
 
@@ -104,12 +104,12 @@ void sock::SetReusePort(FdType fd, int flag) KANON_NOEXCEPT
                           static_cast<socklen_t>(sizeof flag));
 
   if (ret < 0) {
-    LOG_SYSERROR << "setsockopt error(SO_REUSEPORT)";
+    LOG_SYSERROR_KANON << "setsockopt error(SO_REUSEPORT)";
   } else {
-    LOG_INFO << "SO_REUSEPORT option is set to " << static_cast<bool>(flag);
+    LOG_INFO_KANON << "SO_REUSEPORT option is set to " << static_cast<bool>(flag);
   }
 #else
-  LOG_INFO << "linux version less than 3.9, there no reuseport option can set";
+  LOG_INFO_KANON << "linux version less than 3.9, there no reuseport option can set";
 #endif
 #endif
 }
@@ -119,7 +119,7 @@ void sock::SetNoDelay(FdType fd, int flag) KANON_NOEXCEPT
   auto ret = ::setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, (char const *)&flag,
                           static_cast<socklen_t>(sizeof flag));
 
-  if (ret < 0) LOG_SYSERROR << "set sockopt error(tcp: nodelay)";
+  if (ret < 0) LOG_SYSERROR_KANON << "set sockopt error(tcp: nodelay)";
 }
 
 void sock::SetKeepAlive(FdType fd, int flag) KANON_NOEXCEPT
@@ -128,7 +128,7 @@ void sock::SetKeepAlive(FdType fd, int flag) KANON_NOEXCEPT
                           static_cast<socklen_t>(sizeof flag));
 
   if (ret < 0) {
-    LOG_SYSERROR << "set sockeopt error(socket: keepalive)";
+    LOG_SYSERROR_KANON << "set sockeopt error(socket: keepalive)";
   }
 }
 
@@ -139,7 +139,7 @@ struct sockaddr_in6 sock::GetLocalAddr(FdType fd) KANON_NOEXCEPT
   ::memset(&addr, 0, sizeof addr);
 
   if (::getsockname(fd, sock::to_sockaddr(&addr), &len)) {
-    LOG_SYSERROR << "fail to get local address by getsockname()";
+    LOG_SYSERROR_KANON << "fail to get local address by getsockname()";
   }
 
   return addr;
@@ -152,7 +152,7 @@ struct sockaddr_in6 sock::GetPeerAddr(FdType fd) KANON_NOEXCEPT
   ::memset(&addr, 0, sizeof addr);
 
   if (::getpeername(fd, sock::to_sockaddr(&addr), &len)) {
-    LOG_SYSERROR << "fail to get peer address by getpeername()";
+    LOG_SYSERROR_KANON << "fail to get peer address by getpeername()";
   }
 
   return addr;
@@ -164,7 +164,7 @@ static bool GetLocalAddrSafe(FdType fd, struct sockaddr_in6 &addr) KANON_NOEXCEP
   ::memset(&addr, 0, sizeof addr);
 
   if (::getsockname(fd, sock::to_sockaddr(&addr), &len)) {
-    LOG_SYSERROR << "fail to get peer address by getsockname()";
+    LOG_SYSERROR_KANON << "fail to get peer address by getsockname()";
     return false;
   }
   return true;
@@ -175,7 +175,7 @@ static bool GetPeerAddrSafe(FdType fd, struct sockaddr_in6 &addr) KANON_NOEXCEPT
   socklen_t len = sizeof addr;
   ::memset(&addr, 0, sizeof addr);
   if (::getpeername(fd, sock::to_sockaddr(&addr), &len)) {
-    LOG_SYSERROR << "fail to get peer address by getpeerkname()";
+    LOG_SYSERROR_KANON << "fail to get peer address by getpeerkname()";
     return false;
   }
   return true;

--- a/kanon/net/socket.cc
+++ b/kanon/net/socket.cc
@@ -40,7 +40,7 @@ void Socket::ShutdownWrite() KANON_NOEXCEPT
   LOG_TRACE_KANON << "Shutdown peer in write direction";
 
   if (sock::ShutdownWrite(fd_)) {
-    LOG_SYSERROR << "Shutdown write error";
+    LOG_SYSERROR_KANON << "Shutdown write error";
   }
 }
 
@@ -49,6 +49,6 @@ void Socket::ShutdownTwoDirection() KANON_NOEXCEPT
   LOG_TRACE_KANON << "Shutdown peer in two dierction(read/write)";
 
   if (sock::ShutdownTwoDirection(fd_)) {
-    LOG_SYSERROR << "Shutdown read/write error";
+    LOG_SYSERROR_KANON << "Shutdown read/write error";
   }
 }

--- a/kanon/net/tcp_client.cc
+++ b/kanon/net/tcp_client.cc
@@ -110,11 +110,11 @@ void TcpClient::NewConnection(FdType sockfd, InetAddr const &serv_addr,
 
   if (!cli || cli->conn_) return;
 
-  LOG_TRACE << " New connection fd = " << sockfd;
+  LOG_TRACE_KANON << " New connection fd = " << sockfd;
   auto new_conn = TcpConnection::NewTcpConnection(
       cli->loop_, cli->name_, sockfd, sock::GetLocalAddr(sockfd), serv_addr);
 
-  LOG_TRACE << "New connection: " << new_conn.get();
+  LOG_TRACE_KANON << "New connection: " << new_conn.get();
   // Must copy callback instead of moving them
   new_conn->SetMessageCallback(cli->message_callback_);
   new_conn->SetWriteCompleteCallback(cli->write_complete_callback_);
@@ -141,7 +141,7 @@ void TcpClient::NewConnection(FdType sockfd, InetAddr const &serv_addr,
     {
       MutexGuard guard{cli->mutex_};
       cli->conn_.reset();
-      LOG_INFO << conn->GetName() << " has removed";
+      LOG_INFO_KANON << conn->GetName() << " has removed";
     }
 
     // ! In event handling phase, don't remove channel(disable is allowed)

--- a/kanon/net/tcp_server.cc
+++ b/kanon/net/tcp_server.cc
@@ -22,14 +22,14 @@ KANON_INLINE void SignalHandler(int signo, int expected,
                                 char const *msg) KANON_NOEXCEPT
 {
   assert(signo == expected);
-  LOG_INFO << msg;
+  LOG_INFO_KANON << msg;
 
   if (g_loop) {
-    LOG_INFO << "The event loop is quiting...";
+    LOG_INFO_KANON << "The event loop is quiting...";
     g_loop->Quit();
   }
 
-  LOG_INFO << "The server exit successfully";
+  LOG_INFO_KANON << "The server exit successfully";
 }
 
 #ifdef KANON_ON_UNIX
@@ -103,10 +103,10 @@ TcpServer::TcpServer(EventLoop *loop, InetAddr const &listen_addr,
       conn = TcpConnection::NewTcpConnection(io_loop, conn_name, cli_sock, local_addr, cli_addr);  
     }
 #else
-        LOG_TRACE << "Pool block num = " << conn_pool_.GetBlockNum();
-        LOG_TRACE << "Pool usage = "
+        LOG_TRACE_KANON << "Pool block num = " << conn_pool_.GetBlockNum();
+        LOG_TRACE_KANON << "Pool usage = "
                   << conn_pool_.GetUsage(sizeof(TcpConnection));
-        LOG_TRACE << "The number of alive connections: " << connections_.size();
+        LOG_TRACE_KANON << "The number of alive connections: " << connections_.size();
 
         auto conn =
             enable_pool_
@@ -134,7 +134,7 @@ TcpServer::TcpServer(EventLoop *loop, InetAddr const &listen_addr,
           {
             MutexGuard guard(lock_conn_);
             n = connections_.erase(conn->GetName());
-            LOG_TRACE << "The number of alive connections(closing): "
+            LOG_TRACE_KANON << "The number of alive connections(closing): "
                       << connections_.size();
           }
 
@@ -148,10 +148,10 @@ TcpServer::TcpServer(EventLoop *loop, InetAddr const &listen_addr,
 #if 0
           if (conn.use_count() != 1) return;
           if (conn_pool_.IsFull()) {
-            LOG_TRACE << "Delete the connection since pool is full";
+            LOG_TRACE_KANON << "Delete the connection since pool is full";
             delete conn.get();
           } else {
-            LOG_TRACE << "Push the connection to pool";
+            LOG_TRACE_KANON << "Push the connection to pool";
             auto raw_conn = conn.get();
             raw_conn->~TcpConnection();
             conn_pool_.Push(raw_conn);
@@ -211,7 +211,7 @@ void TcpServer::StartRun() KANON_NOEXCEPT
         init_cb_(loop_);
       }
       pool_->StartRun(init_cb_);
-      LOG_INFO << "Listening in " << ip_port_;
+      LOG_INFO_KANON << "Listening in " << ip_port_;
       acceptor_->Listen();
       start_once_ = true;
     });

--- a/kanon/protobuf/logger.cc
+++ b/kanon/protobuf/logger.cc
@@ -1,0 +1,17 @@
+#include "kanon/protobuf/logger.h"
+
+using namespace kanon;
+
+bool kanon::detail::g_kanon_protobuf_log = true;
+
+static int InitKanonProtobufLogEnable() KANON_NOEXCEPT
+{
+  auto enable = ::getenv("KANON_PROTOBUF_LOG_ENABLE");
+  if (enable && !kanon::StrCaseCompare(enable, "0")) {
+    kanon::detail::g_kanon_protobuf_log = false;
+  }
+  return 0;
+}
+
+static int dummy_kanon_protobuf_log_enable_register =
+    InitKanonProtobufLogEnable();

--- a/kanon/protobuf/logger.h
+++ b/kanon/protobuf/logger.h
@@ -1,0 +1,30 @@
+#ifndef KANON_PROTOBUF_LOGGER_H__
+#define KANON_PROTOBUF_LOGGER_H__
+
+#include "kanon/log/logger.h"
+
+namespace kanon {
+namespace detail {
+extern bool g_kanon_protobuf_log;
+} // namespace detail
+} // namespace kanon
+
+#define LOG_TRACE_KANON_PROTOBUF                                               \
+  if (::kanon::detail::g_kanon_protobuf_log) LOG_TRACE
+
+#define LOG_DEBUG_KANON_PROTOBUF                                               \
+  if (::kanon::detail::g_kanon_protobuf_log) LOG_DEBUG
+
+#define LOG_INFO_KANON_PROTOBUF                                                \
+  if (::kanon::detail::g_kanon_protobuf_log) LOG_INFO
+
+#define LOG_WARN_KANON_PROTOBUF                                                \
+  if (::kanon::detail::g_kanon_protobuf_log) LOG_WARN
+
+#define LOG_ERROR_KANON_PROTOBUF                                               \
+  if (::kanon::detail::g_kanon_protobuf_log) LOG_ERROR
+
+#define LOG_SYSERROR_KANON_PROTOBUF                                            \
+  if (::kanon::detail::g_kanon_protobuf_log) LOG_SYSERROR
+
+#endif

--- a/kanon/rpc/logger.cc
+++ b/kanon/rpc/logger.cc
@@ -1,0 +1,17 @@
+#include "kanon/rpc/logger.h"
+
+using namespace kanon;
+
+bool kanon::detail::g_kanon_protobuf_rpc_log_enable = true;
+
+static int InitKanonProtobufRpcLogEnable() KANON_NOEXCEPT
+{
+  auto enable = ::getenv("KANON_PROTOBUF_RPC_LOG_ENABLE");
+  if (enable && !kanon::StrCaseCompare(enable, "0")) {
+    kanon::detail::g_kanon_protobuf_rpc_log_enable = false;
+  }
+  return 0;
+}
+
+static int dummy_kanon_protobuf_rpc_log_enable_register =
+    InitKanonProtobufRpcLogEnable();

--- a/kanon/rpc/logger.h
+++ b/kanon/rpc/logger.h
@@ -1,0 +1,30 @@
+#ifndef KANON_PROTOBUF_RPC_LOGGER_H__
+#define KANON_PROTOBUF_RPC_LOGGER_H__
+
+#include "kanon/log/logger.h"
+
+namespace kanon {
+namespace detail {
+extern bool g_kanon_protobuf_rpc_log_enable;
+} // namespace detail
+} // namespace kanon
+
+#define LOG_TRACE_KANON_PROTOBUF_RPC                                           \
+  if (::kanon::detail::g_kanon_protobuf_rpc_log_enable) LOG_TRACE
+
+#define LOG_DEBUG_KANON_PROTOBUF_RPC                                           \
+  if (::kanon::detail::g_kanon_protobuf_rpc_log_enable) LOG_DEBUG
+
+#define LOG_INFO_KANON_PROTOBUF_RPC                                            \
+  if (::kanon::detail::g_kanon_protobuf_rpc_log_enable) LOG_INFO
+
+#define LOG_WARN_KANON_PROTOBUF_RPC                                            \
+  if (::kanon::detail::g_kanon_protobuf_rpc_log_enable) LOG_WARN
+
+#define LOG_ERROR_KANON_PROTOBUF_RPC                                           \
+  if (::kanon::detail::g_kanon_protobuf_rpc_log_enable) LOG_ERROR
+
+#define LOG_SYSERROR_KANON_PROTOBUF_RPC                                        \
+  if (::kanon::detail::g_kanon_protobuf_rpc_log_enable) LOG_SYSERROR
+
+#endif

--- a/kanon/rpc/rpc_channel.cc
+++ b/kanon/rpc/rpc_channel.cc
@@ -4,6 +4,7 @@
 #include <google/protobuf/stubs/callback.h>
 
 #include "kanon/log/logger.h"
+#include "kanon/rpc/logger.h"
 #include "kanon/net/connection/tcp_connection.h"
 #include "kanon/net/event_loop.h"
 #include "kanon/util/macro.h"
@@ -143,7 +144,7 @@ void RpcChannel::OnRpcMessage(TcpConnectionPtr const &conn,
                "same with the connnection in RpcChannel");
   KANON_UNUSED(conn);
 
-  LOG_DEBUG_KANON << "RpcMessage(Not raw message) receive_time: "
+  LOG_DEBUG_KANON_PROTOBUF_RPC << "RpcMessage(Not raw message) receive_time: "
                   << receive_time.ToFormattedString();
 
   KANON_ASSERT(message->has_type() && message->has_id(),
@@ -295,7 +296,7 @@ void RpcChannel::OnRpcMessageForRequest(TcpConnectionPtr const &conn,
           RpcController *controller = new RpcController;
           if (message->has_deadline()) {
             controller->SetDeadline(message->deadline());
-            LOG_DEBUG << "deadline=" << controller->deadline() << " Ms";
+            LOG_DEBUG_KANON_PROTOBUF_RPC << "deadline=" << controller->deadline() << " Ms";
           }
           service->CallMethod(
               method, controller, request, response,

--- a/kanon/rpc/rpc_channel.cc
+++ b/kanon/rpc/rpc_channel.cc
@@ -163,6 +163,8 @@ void RpcChannel::OnRpcMessage(TcpConnectionPtr const &conn,
 void RpcChannel::OnRpcMessageForResponse(TcpConnectionPtr const &conn,
                                          RpcMessagePtr message, TimeStamp stamp)
 {
+  KANON_UNUSED(conn);
+  KANON_UNUSED(stamp);
   /**
    * Receive the response from the RpcServer
    * 0. Check error, response
@@ -234,6 +236,8 @@ void RpcChannel::OnRpcMessageForResponse(TcpConnectionPtr const &conn,
 void RpcChannel::OnRpcMessageForRequest(TcpConnectionPtr const &conn,
                                         RpcMessagePtr message, TimeStamp stamp)
 {
+  KANON_UNUSED(conn);
+  KANON_UNUSED(stamp);
   /**
    * Receive the request message from RpcClient
    * 1. Check the service

--- a/kanon/rpc/rpc_controller.cc
+++ b/kanon/rpc/rpc_controller.cc
@@ -1,5 +1,6 @@
 #include "rpc_controller.h"
 
+#include "kanon/rpc/logger.h"
 #include "kanon/net/event_loop.h"
 
 #include "kanon/rpc/rpc.pb.h"
@@ -37,8 +38,8 @@ bool RpcController::IsCanceled() const
 {
   if (deadline_ != (Deadline)-1) {
     uint64_t now_ms = TimeStamp::Now().GetMicrosecondsSinceEpoch() / 1000;
-    LOG_DEBUG_KANON << "Now: " << now_ms;
-    LOG_DEBUG_KANON << "deadline: " << deadline();
+    LOG_DEBUG_KANON_PROTOBUF_RPC << "Now: " << now_ms;
+    LOG_DEBUG_KANON_PROTOBUF_RPC << "deadline: " << deadline();
     if (now_ms > deadline()) return true;
   }
 

--- a/kanon/rpc/rpc_controller.cc
+++ b/kanon/rpc/rpc_controller.cc
@@ -14,7 +14,8 @@ RpcController::RpcController()
 
 RpcController::~RpcController() noexcept {}
 
-void RpcController::Reset() {
+void RpcController::Reset()
+{
   deadline_ = (Deadline)-1;
 }
 
@@ -27,7 +28,10 @@ void RpcController::StartCancel() {}
 
 void RpcController::SetFailed(std::string const & /*reason*/) {}
 
-std::string RpcController::ErrorText() const { return ""; }
+std::string RpcController::ErrorText() const
+{
+  return "";
+}
 
 bool RpcController::IsCanceled() const
 {
@@ -41,4 +45,7 @@ bool RpcController::IsCanceled() const
   return false;
 }
 
-void RpcController::NotifyOnCancel(::google::protobuf::Closure *cb) {}
+void RpcController::NotifyOnCancel(::google::protobuf::Closure *cb)
+{
+  KANON_UNUSED(cb);
+}

--- a/kanon/rpc/rpc_server.cc
+++ b/kanon/rpc/rpc_server.cc
@@ -6,7 +6,7 @@
 using namespace kanon::protobuf::rpc;
 
 RpcServer::RpcServer(EventLoop *loop, InetAddr const &addr, StringArg name,
-                       bool reuseport)
+                     bool reuseport)
   : TcpServer(loop, addr, name, reuseport)
 {
   SetConnectionCallback([this](TcpConnectionPtr const &conn) {

--- a/kanon/string/string_view.h
+++ b/kanon/string/string_view.h
@@ -179,11 +179,13 @@ class StringView {
     return data_[n];
   }
 
-  constexpr const_reference at(size_type n) const
+  KANON_CONSTEXPR KANON_ALWAYS_INLINE const_reference at(size_type n) const
   {
-    return n >= len_ ? throw std::length_error{"Given index over or equal "
-                                               "length of StringView"}
-                     : data_[n];
+    if (KANON_UNLIKELY(n >= len_)) {
+      throw std::length_error{"Given index over or equal "
+                              "length of StringView"};
+    }
+    return data_[n];
   }
 
   constexpr const_reference front() const KANON_NOEXCEPT

--- a/kanon/win/net/buffer.cc
+++ b/kanon/win/net/buffer.cc
@@ -47,7 +47,7 @@ void kanon::BufferOverlapRecv(Buffer &buffer, FdType fd, int &saved_errno,
   }
 }
 
-usize kanon::BufferReadFromFd(Buffer &buffer, FdType fd, int &saved_errno)
+usize kanon::BufferReadFromFd(Buffer &, FdType, int &)
 {
   LOG_FATAL << "BufferReadFromFd() isn't implemented for Windows";
   return usize(-1);

--- a/kanon/win/net/buffer.cc
+++ b/kanon/win/net/buffer.cc
@@ -12,7 +12,7 @@ using namespace kanon;
 void kanon::BufferOverlapRecv(Buffer &buffer, FdType fd, int &saved_errno,
                               void *overlap)
 {
-  LOG_TRACE << "BufferOverlapRecv(), fd = " << fd;
+  LOG_TRACE_KANON << "BufferOverlapRecv(), fd = " << fd;
 
   auto conn = (TcpConnection *)overlap;
   auto ch = conn->channel();
@@ -34,14 +34,14 @@ void kanon::BufferOverlapRecv(Buffer &buffer, FdType fd, int &saved_errno,
   switch (ret) {
     case 0: // Complete immediately
     {
-      LOG_TRACE << "WSARecv() complete immediately";
+      LOG_TRACE_KANON << "WSARecv() complete immediately";
       // conn->HandleReadImmediately(recv_bytes);
     } break;
 
     case SOCKET_ERROR: {
       auto err = WSAGetLastError();
       if (err != WSA_IO_PENDING) {
-        LOG_SYSERROR << "Failed to call WSARecv()";
+        LOG_SYSERROR_KANON << "Failed to call WSARecv()";
       }
     } break;
   }

--- a/kanon/win/net/chunk_list.cc
+++ b/kanon/win/net/chunk_list.cc
@@ -68,8 +68,8 @@ void kanon::ChunkListOverlapSend(ChunkList &buffer, FdType fd, int &saved_errno,
   }
 }
 
-ChunkList::SizeType kanon::ChunkListWriteFd(ChunkList &buffer, FdType fd,
-                                            int &saved_errno) KANON_NOEXCEPT
+ChunkList::SizeType kanon::ChunkListWriteFd(ChunkList &, FdType,
+                                            int &) KANON_NOEXCEPT
 {
   LOG_FATAL << "ChunkListWriteFd() isn't implemented for Windows";
   return (-1);

--- a/kanon/win/net/chunk_list.cc
+++ b/kanon/win/net/chunk_list.cc
@@ -26,7 +26,7 @@ static CompletionContext *cached_completion_context = nullptr;
 void kanon::ChunkListOverlapSend(ChunkList &buffer, FdType fd, int &saved_errno,
                                  void *overlap)
 {
-  LOG_TRACE << "ChunkListOverlapSend, fd = " << fd;
+  LOG_TRACE_KANON << "ChunkListOverlapSend, fd = " << fd;
   auto conn = (TcpConnection *)overlap;
   auto ch = conn->channel();
   auto &bufs = conn->wsabufs;
@@ -50,7 +50,7 @@ void kanon::ChunkListOverlapSend(ChunkList &buffer, FdType fd, int &saved_errno,
   switch (ret) {
     case 0: // Complete immediately
     {
-      LOG_TRACE << "WSASend() complete immediately";
+      LOG_TRACE_KANON << "WSASend() complete immediately";
       // conn->HandleWriteImmediately(send_bytes);
     } break;
     case SOCKET_ERROR: {
@@ -59,7 +59,7 @@ void kanon::ChunkListOverlapSend(ChunkList &buffer, FdType fd, int &saved_errno,
         cached_completion_context = nullptr;
       } else {
         conn->ForceClose();
-        LOG_SYSERROR << "Failed to call WSASend()";
+        LOG_SYSERROR_KANON << "Failed to call WSASend()";
       }
     } break;
 

--- a/kanon/win/net/connection/connection_base.inl
+++ b/kanon/win/net/connection/connection_base.inl
@@ -26,7 +26,7 @@ void ConnectionBase<D>::HandleRead(TimeStamp recv_time)
     message_callback_(shared_from_this(), input_buffer_, recv_time);
   } else {
     input_buffer_.AdvanceAll();
-    LOG_WARN << "If user want to process message from peer, should set "
+    LOG_WARN_KANON << "If user want to process message from peer, should set "
                 "proper message_callback_";
   }
 
@@ -121,7 +121,7 @@ void ConnectionBase<D>::HandleReadImmediately(size_t readn)
     }
   } else {
     input_buffer_.AdvanceAll();
-    LOG_WARN << "If user want to process message from peer, should set "
+    LOG_WARN_KANON << "If user want to process message from peer, should set "
                 "proper message_callback_";
   }
 

--- a/kanon/win/net/connector.cc
+++ b/kanon/win/net/connector.cc
@@ -33,8 +33,8 @@ void Connector::Connect()
   if (!ret) {
     auto saved_errno = ::WSAGetLastError();
     auto err = GetLastError();
-    LOG_ERROR << "err = " << err;
-    LOG_ERROR << "wsa error = " << saved_errno;
+    LOG_ERROR_KANON << "err = " << err;
+    LOG_ERROR_KANON << "wsa error = " << saved_errno;
     switch (saved_errno) {
       case WSA_IO_PENDING:
         // case WSAEINPROGRESS:
@@ -49,7 +49,7 @@ void Connector::Connect()
         Retry(sockfd);
         break;
       default:
-        LOG_SYSERROR << "Failed to call ConnectEx()";
+        LOG_SYSERROR_KANON << "Failed to call ConnectEx()";
         sock::Close(sockfd);
         ResetChannel();
         ::WSACleanup();
@@ -82,14 +82,14 @@ void Connector::CompleteConnect(FdType sockfd)
                                 (char *)&seconds, (PINT)&bytes);
       bool can_retry = false;
       if (iResult != NO_ERROR) {
-        LOG_SYSERROR << "Failed to call getsockopt(SO_CONNECT_TIME)";
+        LOG_SYSERROR_KANON << "Failed to call getsockopt(SO_CONNECT_TIME)";
         can_retry = true;
       } else {
         if (seconds == (0xffffffff)) {
-          LOG_DEBUG << "Connection isn't established!";
+          LOG_DEBUG_KANON << "Connection isn't established!";
           can_retry = true;
         } else {
-          LOG_DEBUG << "Connection has been established " << seconds
+          LOG_DEBUG_KANON << "Connection has been established " << seconds
                     << " seconds";
         }
       }
@@ -103,13 +103,13 @@ void Connector::CompleteConnect(FdType sockfd)
       if (setsockopt(sockfd, SOL_SOCKET, SO_UPDATE_CONNECT_CONTEXT,
                      (char const *)&flag, sizeof(flag)))
       {
-        LOG_SYSERROR << "Failed to setsockopt(SO_UPDATE_CONNECT_CONTEXT)";
+        LOG_SYSERROR_KANON << "Failed to setsockopt(SO_UPDATE_CONNECT_CONTEXT)";
       }
 
       if (err) {
         // Fatal errors have handled in Connect()
-        LOG_WARN << "SO_ERROR = " << err << " " << strerror_tl(err);
-        LOG_SYSERROR << "GetOverlappedResult(): ";
+        LOG_WARN_KANON << "SO_ERROR = " << err << " " << strerror_tl(err);
+        LOG_SYSERROR_KANON << "GetOverlappedResult(): ";
         Retry(sockfd);
       } else if (sock::IsSelfConnect(sockfd)) {
         // Self connection happend only when:
@@ -123,7 +123,7 @@ void Connector::CompleteConnect(FdType sockfd)
         // \see /proc/sys/net/ipv4/ip_local_port_range
         // \see
         // https://github.com/pirDOL/kaka/blob/master/Miscellaneous/TCP-client-self-connect.md
-        LOG_WARN << "self connect";
+        LOG_WARN_KANON << "self connect";
         // Discard the client address and retry
         // until self connection is skipped
         Retry(sockfd);
@@ -134,13 +134,13 @@ void Connector::CompleteConnect(FdType sockfd)
           if (new_connection_callback_) {
             new_connection_callback_(sockfd);
           } else {
-            LOG_WARN << "There is no new connection callback, cannot to create "
+            LOG_WARN_KANON << "There is no new connection callback, cannot to create "
                         "connection";
           }
           LOG_TRACE_KANON << "Connection is established successfully";
         } else {
           // Must after Stop() is called
-          LOG_WARN << "Cannot to complete connect since user stop it";
+          LOG_WARN_KANON << "Cannot to complete connect since user stop it";
           sock::Close(sockfd);
         }
       }
@@ -153,7 +153,7 @@ void Connector::CompleteConnect(FdType sockfd)
       ResetChannel();
       int err = sock::GetSocketError(sockfd);
       if (err) {
-        LOG_ERROR << "SO_ERROR = " << err << " " << strerror_tl(err);
+        LOG_ERROR_KANON << "SO_ERROR = " << err << " " << strerror_tl(err);
       }
 
       Retry(sockfd);

--- a/kanon/win/net/init.cc
+++ b/kanon/win/net/init.cc
@@ -11,7 +11,7 @@ void kanon::KanonNetInitialize()
     LOG_TRACE_KANON << "Kanon net resources initialization: OK";
     return;
   }
-  LOG_ERROR << "Kanon net resources initialization: Failed";
+  LOG_ERROR_KANON << "Kanon net resources initialization: Failed";
 
   switch (err) {
     case WSASYSNOTREADY:
@@ -37,7 +37,7 @@ void kanon::KanonNetTeardown() KANON_NOEXCEPT
     const auto err = ::WSAGetLastError();
     switch (err) {
       case WSANOTINITIALISED:
-        LOG_ERROR << "KanonNetTeardown() has called successfully before "
+        LOG_ERROR_KANON << "KanonNetTeardown() has called successfully before "
                      "calling this function";
         break;
       case WSAENETDOWN:
@@ -46,7 +46,7 @@ void kanon::KanonNetTeardown() KANON_NOEXCEPT
       case WSAEINPROGRESS:
         return;
       default:
-        LOG_ERROR << "Kanon net resources teardown: Failed";
+        LOG_ERROR_KANON << "Kanon net resources teardown: Failed";
         LOG_SYSFATAL
             << "Unexpected error occurred when releasing net resources";
     }

--- a/kanon/win/net/iocp_poller.cc
+++ b/kanon/win/net/iocp_poller.cc
@@ -73,8 +73,8 @@ TimeStamp IocpPoller::Poll(int ms, ChannelVec &active_channels)
     for (size_t i = 0; i < removed_entries_num; ++i) {
       auto &entry = entries_[i];
       auto ch = (Channel *)entry.lpCompletionKey;
-      LOG_DEBUG << "Channel ID = [" << ch << "]";
-      LOG_DEBUG << "Transferred bytes = " << entry.dwNumberOfBytesTransferred;
+      LOG_DEBUG_KANON << "Channel ID = [" << ch << "]";
+      LOG_DEBUG_KANON << "Transferred bytes = " << entry.dwNumberOfBytesTransferred;
       ch->transferred_bytes = entry.dwNumberOfBytesTransferred;
       ch->PushCompleteContext((CompletionContext *)entry.lpOverlapped);
       active_channels.push_back(ch);

--- a/kanon/win/net/sock_api.cc
+++ b/kanon/win/net/sock_api.cc
@@ -52,7 +52,7 @@ FdType sock::CreateNonBlockAndCloExecSocket(bool ipv6) KANON_NOEXCEPT
     LOG_SYSFATAL << "create new socket fd error";
     return INVALID_SOCKET;
   } else {
-    LOG_DEBUG << "New socket = " << sockfd;
+    LOG_DEBUG_KANON << "New socket = " << sockfd;
   }
   return sockfd;
 }
@@ -65,7 +65,7 @@ FdType sock::CreateOverlappedSocket(bool ipv6) KANON_NOEXCEPT
     LOG_SYSFATAL << "create new socket fd error";
     return INVALID_SOCKET;
   } else {
-    LOG_DEBUG << "New socket = " << sockfd;
+    LOG_DEBUG_KANON << "New socket = " << sockfd;
   }
   return sockfd;
 }
@@ -98,7 +98,7 @@ FdType sock::Accept(FdType fd, sockaddr_in6 *addr) KANON_NOEXCEPT
     if (setsockopt(cli_sock, SOL_SOCKET, SO_UPDATE_ACCEPT_CONTEXT,
                    (char const *)&flag, sizeof(flag)))
     {
-      LOG_SYSERROR << "Failed to setsockopt(SO_UPDATE_ACCPET_CONTEXT)";
+      LOG_SYSERROR_KANON << "Failed to setsockopt(SO_UPDATE_ACCPET_CONTEXT)";
     }
 
     if (bRetVal == FALSE) {

--- a/kanon/win/net/timer/timer_queue.cc
+++ b/kanon/win/net/timer/timer_queue.cc
@@ -19,7 +19,7 @@ TimerQueue::~TimerQueue() KANON_NOEXCEPT { DeleteTimerQueueEx(timer_queue_, NULL
 
 VOID kanon::timer_callback(_In_ PVOID ctx, _In_ BOOLEAN timer_fired)
 {
-  LOG_TRACE << "Timer callback";
+  LOG_TRACE_KANON << "Timer callback";
   if (timer_fired) {
     auto timer = (Timer *)ctx;
     timer->timer_queue()->loop()->QueueToLoop([timer]() {
@@ -28,7 +28,7 @@ VOID kanon::timer_callback(_In_ PVOID ctx, _In_ BOOLEAN timer_fired)
         timer->timer_queue()->timer_map_.erase(timer->sequence());
     });
   } else {
-    LOG_WARN << "This is maybe not a valid timer";
+    LOG_WARN_KANON << "This is maybe not a valid timer";
   }
 }
 

--- a/test/log/logger_level_test.cc
+++ b/test/log/logger_level_test.cc
@@ -1,0 +1,25 @@
+#include "kanon/log/logger.h"
+
+using namespace kanon;
+
+#define FATAL_BIT kanon::Logger::KANON_LL_FATAL
+
+int main()
+{
+  if ((kanon::Logger::KANON_LL_FATAL & kanon::Logger::KANON_LL_FATAL) &
+      (kanon::Logger::KANON_LL_SYS_FATAL & kanon::Logger::KANON_LL_FATAL))
+  {
+    printf("These are Fatal levels\n");
+  }
+
+  if (!(kanon::Logger::KANON_LL_ERROR & FATAL_BIT)) {
+    printf("There are not fatal level\n");
+  }
+
+  LOG_TRACE << "TRACE";
+  LOG_DEBUG << "DEBUG";
+  LOG_INFO << "INFO";
+  LOG_WARN << "WARN";
+  LOG_ERROR << "ERROR";
+  // LOG_FATAL << "FATAL";
+}


### PR DESCRIPTION
FIX: 检查更多的warning，将潜在bug修正
MOD：log级别增加OFF，修改环境变量值为KANON_LOG指定最低级别
MOD：kanon、kanon-protobuf、kanon-protobuf-rpc三个部分都设置一个变量表示启动日志，可以通过环境变量设置，用户可以根据自己需要开启库级别的日志，全部禁止表示只输出用户的应用日志（如果是库用户，可以类似设置一个变量控制自己模块的日志）